### PR TITLE
(fix) Improve Repository Name Regex in Jenkins Script

### DIFF
--- a/Bootstrap.ps1
+++ b/Bootstrap.ps1
@@ -70,11 +70,11 @@ if (-not (Get-Module C4B-Environment -ListAvailable)) {
 }
 
 if (-not (Get-ChildItem $OutputPath) -or $env:UpdateBootstrap) {
-    Invoke-WebRequest -Uri "https://api.github.com/repos/chocolatey/choco-orgguide-scripts/zipball/main" -OutFile $env:Temp\orgscripts.zip
+    Invoke-WebRequest -Uri "https://api.github.com/repos/chocolatey-solutions/choco-orgguide-scripts/zipball/main" -OutFile $env:Temp\orgscripts.zip
     Expand-Archive $env:Temp\orgscripts.zip $OutputPath -Force
-    Copy-Item $OutputPath\chocolatey-choco-orgguide-scripts-*\* $OutputPath -Force
+    Copy-Item $OutputPath\chocolatey-solutions-choco-orgguide-scripts-*\* $OutputPath -Force
     Remove-Item $env:Temp\orgscripts.zip
-    Remove-Item $OutputPath\chocolatey-choco-orgguide-scripts-* -Recurse
+    Remove-Item $OutputPath\chocolatey-solutions-choco-orgguide-scripts-* -Recurse
 }
 
 # TEMPORARY WORKAROUND FOR LICENSE FEED

--- a/Bootstrap.ps1
+++ b/Bootstrap.ps1
@@ -77,16 +77,5 @@ if (-not (Get-ChildItem $OutputPath) -or $env:UpdateBootstrap) {
     Remove-Item $OutputPath\chocolatey-solutions-choco-orgguide-scripts-* -Recurse
 }
 
-# TEMPORARY WORKAROUND FOR LICENSE FEED
-# TODO: Remove
-if (Test-Path ~\Desktop\c4b-environment.powershell.*.nupkg) {
-    try {
-        Push-Location ~\Desktop
-        choco upgrade c4b-environment.powershell --source . --confirm  --no-progress
-    } finally {
-        Pop-Location
-    }
-}
-
 # Open the new location
 Set-Location $OutputPath

--- a/Install-C4BAutomationPlatformJenkins.ps1
+++ b/Install-C4BAutomationPlatformJenkins.ps1
@@ -70,7 +70,7 @@ try {
     # We need to add each of the repositories so that we can use them in jobs
     foreach ($Repository in 'ChocolateyCore', 'Production', 'Test') {
         $Url = Get-Variable "$($Repository)RepositoryUrl" -ValueOnly
-        $Name = if ($Url -match '/(?<RepositoryName>.+)/(?<v3>index.json)?$') {
+        $Name = if ($Url -match '/(?<RepositoryName>[-\w]+)/(?<v3>index.json)?$') {
             $Matches.RepositoryName
         } else {
             $Repository


### PR DESCRIPTION
Ryan observed an issue with the automatic recognition of the repository name. This change makes the match less potentially greedy.

Additionally, fixes some hardcoded references to the previous org name, and removes a temporary workaround for the installation / upgrade of C4B-Environment (which is no longer required due to the addition of the package to the licensed feed).